### PR TITLE
Removing 'www' from google movies URL

### DIFF
--- a/lib/google_movies.rb
+++ b/lib/google_movies.rb
@@ -8,7 +8,7 @@ module GoogleMovies
   
   class Client
     
-    ROOT_URL = "http://www.google.com/movies"
+    ROOT_URL = "http://google.com/movies"
     
     def initialize(city)
       @city = city


### PR DESCRIPTION
Sometimes we can't access www on google movies URL, don't know why but that happenned with me.
