### PR TITLE
rack-test on gemspec

### DIFF
--- a/google_movies.gemspec
+++ b/google_movies.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'nokogiri'
   gem.add_development_dependency 'vcr'
   gem.add_development_dependency 'webmock', '1.8.0'
+  gem.add_development_dependency 'rack-test'
 end


### PR DESCRIPTION
Adding it, cause I was getting errors while trying to run test suite using ruby 1.9.3
